### PR TITLE
Fix bug with large files reporting wrong size (titledumper)

### DIFF
--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -27,8 +27,6 @@
 #include <inttypes.h>
 #ifndef __APPLE__
 #include <malloc.h>
-#define fopen64 fopen
-#define ftello64 ftello
 #endif
 #include <sys/stat.h>
 #include "Input.h"
@@ -185,6 +183,9 @@ void processTag(int client_socket, SendData *sendData)
         {
             lastTime = gettime();
             lastSize = 0;
+#ifdef __APPLE__
+#define fopen64 fopen
+#endif
             pFile = fopen64(localPath, "wb");
             printf("Open file: %s\n", localPath);
             if(!pFile) {
@@ -198,6 +199,9 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
+#ifdef __APPLE__
+#define ftello64 ftello
+#endif
         uint64_t size = (uint64_t)ftello64(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;

--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -183,6 +183,9 @@ void processTag(int client_socket, SendData *sendData)
         {
             lastTime = gettime();
             lastSize = 0;
+#ifdef __APPLE__
+#define fopen64 fopen
+#endif
             pFile = fopen64(localPath, "wb");
             printf("Open file: %s\n", localPath);
             if(!pFile) {
@@ -196,12 +199,14 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
+#ifdef __APPLE__
+#define ftello64 ftello
+#endif
         uint64_t size = (uint64_t)ftello64(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;
         float fSpeed = (fTimeDiff == 0.0f) ? 0.0f : ( (float)size / fTimeDiff / 1024.0f );
         printf("Read file %" PRIu64 " kb loaded with %0.3f kb/s\r", size / 1024, fSpeed);
-        //printf(size);
         fwrite(sendData->data, 1, le32(sendData->length), pFile);
         break;
     }

--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -28,6 +28,10 @@
 #ifndef __APPLE__
 #include <malloc.h>
 #endif
+#ifdef __APPLE__
+#define fopen64 fopen
+#define ftello64 ftello
+#endif
 #include <sys/stat.h>
 #include "Input.h"
 #include "network.h"
@@ -183,9 +187,6 @@ void processTag(int client_socket, SendData *sendData)
         {
             lastTime = gettime();
             lastSize = 0;
-#ifdef __APPLE__
-#define fopen64 fopen
-#endif
             pFile = fopen64(localPath, "wb");
             printf("Open file: %s\n", localPath);
             if(!pFile) {
@@ -199,9 +200,6 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
-#ifdef __APPLE__
-#define ftello64 ftello
-#endif
         uint64_t size = (uint64_t)ftello64(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;

--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
 #ifndef __APPLE__
 #include <malloc.h>
 #endif
@@ -182,7 +183,7 @@ void processTag(int client_socket, SendData *sendData)
         {
             lastTime = gettime();
             lastSize = 0;
-            pFile = fopen(localPath, "wb");
+            pFile = fopen64(localPath, "wb");
             printf("Open file: %s\n", localPath);
             if(!pFile) {
                 printf("Failed to open: %s\n", localPath);
@@ -195,11 +196,12 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
-        unsigned long int size = ftell(pFile);
+        uint64_t size = (uint64_t)ftello64(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;
         float fSpeed = (fTimeDiff == 0.0f) ? 0.0f : ( (float)size / fTimeDiff / 1024.0f );
-        printf("Read file %lu kb loaded with %0.3f kb/s\r", size / 1024, fSpeed);
+        printf("Read file %" PRIu64 " kb loaded with %0.3f kb/s\r", size / 1024, fSpeed);
+        //printf(size);
         fwrite(sendData->data, 1, le32(sendData->length), pFile);
         break;
     }

--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -195,11 +195,11 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
-        unsigned int size = ftell(pFile);
+        unsigned long int size = ftell(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;
         float fSpeed = (fTimeDiff == 0.0f) ? 0.0f : ( (float)size / fTimeDiff / 1024.0f );
-        printf("Read file %i kb loaded with %0.3f kb/s\r", size / 1024, fSpeed);
+        printf("Read file %lu kb loaded with %0.3f kb/s\r", size / 1024, fSpeed);
         fwrite(sendData->data, 1, le32(sendData->length), pFile);
         break;
     }

--- a/titledumper/source/main.c
+++ b/titledumper/source/main.c
@@ -27,6 +27,8 @@
 #include <inttypes.h>
 #ifndef __APPLE__
 #include <malloc.h>
+#define fopen64 fopen
+#define ftello64 ftello
 #endif
 #include <sys/stat.h>
 #include "Input.h"
@@ -183,9 +185,6 @@ void processTag(int client_socket, SendData *sendData)
         {
             lastTime = gettime();
             lastSize = 0;
-#ifdef __APPLE__
-#define fopen64 fopen
-#endif
             pFile = fopen64(localPath, "wb");
             printf("Open file: %s\n", localPath);
             if(!pFile) {
@@ -199,9 +198,6 @@ void processTag(int client_socket, SendData *sendData)
         if(!pFile) {
             break;
         }
-#ifdef __APPLE__
-#define ftello64 ftello
-#endif
         uint64_t size = (uint64_t)ftello64(pFile);
         unsigned int time = gettime();
         float fTimeDiff = (time - lastTime) * 0.001f;


### PR DESCRIPTION
- Large files would cause the output to show 4194303 KB transferred, or
  the max value of an unsigned int / 1024.
- Changed size in main.c from unsigned int to unsigned long int.
- Not sure why this happens, as the files weren't that big. (Only tested with Xenoblade Chronicles X, max file size 2,945,097 KB)
